### PR TITLE
Add Codex configuration example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ For Claude Desktop, add to your `claude_desktop_config.json`:
 }
 ```
 
+#### Codex Configuration
+
+For Codex, add to your `.codex/config.toml`:
+
+```toml
+[mcp_servers.sejm_mcp]
+command = "docker"
+args = [ "run", "-i", "--rm", "ghcr.io/janisz/sejm-mcp:latest" ]
+```
+
 #### Local Binary Usage
 
 If you prefer to build and run locally:


### PR DESCRIPTION
- Add TOML configuration section for Codex users
- Include example .codex/config.toml usage
- Place logically after Claude Desktop configuration

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Documentation:
- Add a new section in README with a TOML configuration example for Codex users